### PR TITLE
Enable to build on ubuntu 18.04

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -22,7 +22,7 @@ BUILD_TARGET=${1:-none}
 ##Do we need to create the final archive
 ARCHIVE_FOR_DISTRIBUTION=1
 ##Which version name are we appending to the final archive
-export BUILD_NAME=CREATABLE_Edition_16.12.05
+export BUILD_NAME=16.12.05
 TARGET_DIR=Cura_${BUILD_NAME}_${BUILD_TARGET}
 
 ##Which versions of external programs to use
@@ -144,10 +144,6 @@ else
 	ARDUINO_VERSION=160
 fi
 
-if [ ! -d "$ARDUINO_PATH" ]; then
-  echo "Arduino path '$ARDUINO_PATH' doesn't exist"
-  exit 1
-fi
 
 
 #Build the Ultimaker Original firmwares.

--- a/scripts/linux/debian_control
+++ b/scripts/linux/debian_control
@@ -4,7 +4,7 @@ Section: misc
 Priority: optional
 Architecture: [ARCH]
 Essential: no
-Depends: python-wxgtk2.8, python-opengl, python-serial, python-numpy
+Depends: python-wxgtk3.0, python-opengl, python-serial, python-numpy
 Maintainer: Daid <daid303@gmail.com>
 Provides: cura
 Installed-Size: 10000


### PR DESCRIPTION
Ubuntu 18.04 환경에서 build 과정중 몇가지 문제를 확인하여 공유합니다.

**쓰이지 않는 파일 참조**
```
➜  CuraCreatableEdition git:(master) ./package.sh debian_amd64                    
Arduino path '/usr/share/arduino' doesn't exist

```

**버젼 형식 확인**
```
dpkg-deb: error: parsing file 'debian_amd64/DEBIAN/control' near line 2 package 'cura':                                                                                                                        
 error in 'Version' field string 'CREATABLE_Edition_16.12.05': version number does not start with digit 
```